### PR TITLE
add tags to the strapi request

### DIFF
--- a/backend/app/src/api/mailchimp-subscribe/controllers/mailchimp-subscribe.js
+++ b/backend/app/src/api/mailchimp-subscribe/controllers/mailchimp-subscribe.js
@@ -24,6 +24,7 @@ module.exports = {
             email_address: email,
             full_name: fullName,
             status: !!subscribe === true ? "subscribed" : "unsubscribed",
+            tags: [{ name: "IMCON", status: "active" }],
           },
         });
       const { _links, ...res } = response;


### PR DESCRIPTION
tags can be added to the Mailchimp POST request to add members to lists.